### PR TITLE
Update tmux key binding to v2.4

### DIFF
--- a/bin/dotfiles
+++ b/bin/dotfiles
@@ -735,7 +735,7 @@ do_reconfigure() {
   make_symlink ".zshrc.local" "${PROJECT_SETTINGS_THEME_DIR}/.zshrc.local" "$HOME/.zshrc.local"
 
   # $PATH variable not properly set in gvim/MacVim => http://stackoverflow.com/a/24542893/1977012
-  make_symlink ".zprofile" "${PROJECT_SETTINGS_COMMON_DIR}/.zshrc" "$HOME/.zprofile"
+  make_symlink ".zprofile" "${PROJECT_SETTINGS_COMMON_DIR}/.zprofile" "$HOME/.zprofile"
 
 
   # Copy specyfic folders

--- a/settings/common/.tmux-osx.conf
+++ b/settings/common/.tmux-osx.conf
@@ -6,12 +6,12 @@ set -g default-shell $SHELL
 set -g default-command "reattach-to-user-namespace -l ${SHELL}"
 
 # Setup 'v' to begin selection as in Vim
-bind-key -T copy-mode-vi v begin-selection
-bind-key -T copy-mode-vi y copy-pipe "reattach-to-user-namespace pbcopy"
+bind-key -T copy-mode-vi v send-keys -X begin-selection
+bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
 
 # Update default binding of `Enter` to also use copy-pipe
-unbind -T copy-mode-vi Enter
-bind-key -T copy-mode-vi Enter copy-pipe "reattach-to-user-namespace pbcopy"
+unbind-key -T copy-mode-vi Enter
+bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
 
 set-option -g default-command "reattach-to-user-namespace -l zsh"
 # vim: set ft=tmux tw=0 nowrap:

--- a/settings/common/.tmux.conf
+++ b/settings/common/.tmux.conf
@@ -16,17 +16,17 @@ set-window-option -g xterm-keys on
 ## General
 ###########################
 # Change prefix key to
-unbind C-a
-unbind C-b
+unbind-key C-a
+unbind-key C-b
 set-option -g prefix C-a  # first prefix
 set-option -g prefix2 C-b # second prefix
 
 # C-a a should send ctrl-a to the underlying shell (move to start of line)
 bind-key a send-prefix
 
-# quick pane cycling
-unbind ^A
-bind-key ^A select-pane -T :.+
+# Quick pane cycling
+# unbind-key C-a
+# bind-key C-a select-pane -T :.+
 
 #
 # set mouse on with prefix m
@@ -87,14 +87,14 @@ setw -g pane-base-index 1
 set-window-option -g mode-keys vi
 
 # unbind arrow keys
-unbind C-Up
-unbind C-Up
-unbind C-Down
-unbind C-Left
-unbind M-Right
-unbind M-Down
-unbind M-Left
-unbind M-Right
+unbind-key C-Up
+unbind-key C-Up
+unbind-key C-Down
+unbind-key C-Left
+unbind-key M-Right
+unbind-key M-Down
+unbind-key M-Left
+unbind-key M-Right
 
 # Config for vim-like movements;
 # based on https://github.com/sdball/dotfiles/blob/master/.tmux.conf
@@ -133,10 +133,9 @@ bind-key + resize-pane -U 5
 bind-key = resize-pane -U 5 # This is as alias to not use Shift key
 
 # Scroll
-# bind-key Up   history-up
-# bind-key Down history-down
-bind-key -T copy-mode-vi Up page-up
-bind-key -T copy-mode-vi Down page-down
+bind-key Escape copy-mode # enter to scroll mode
+bind-key -T copy-mode-vi Up send-keys -X page-up # bind-key Up   history-up
+bind-key -T copy-mode-vi Down send-keys -X page-down # bind-key Down history-down
 
 # # split windows like vim
 bind-key s split-window -v
@@ -145,13 +144,16 @@ bind-key v split-window -h
 # copying selection vim style
 # http://jasonwryan.com/blog/2011/06/07/copy-and-paste-in-tmux/
 # https://github.com/myfreeweb/dotfiles/blob/master/tmux.conf
-bind-key Escape copy-mode               # enter copy mode
-bind-key -T copy-mode-vi Escape cancel       # exit copy mode; or hit q
-bind-key p paste-buffer                 # paste; default ]
-bind-key -T copy-mode-vi 'v' begin-selection     # begin visual mode
-bind-key -T copy-mode-vi 'V' select-line         # visual line
-bind-key -T copy-mode-vi 'y' copy-selection      # yank
-bind-key -T copy-mode-vi 'r' rectangle-toggle    # visual block toggle
+unbind-key -T copy-mode-vi Escape
+bind-key -T copy-mode-vi Escape send-keys -X cancel  # exit copy mode with Escape;
+
+bind-key p paste-buffer # paste; default ]
+
+bind-key -T copy-mode-vi v send-keys -X begin-selection     # begin visual mode
+bind-key -T copy-mode-vi V send-keys -X select-line         # visual line
+bind-key -T copy-mode-vi y send-keys -X copy-selection      # yank
+
+bind-key -T copy-mode-vi C-v send-keys -X rectangle-toggle  # visual block toggle
 
 bind-key -n F11 prev
 bind-key -n F12 next-window


### PR DESCRIPTION
Fixes #58 

## Proposed Changes

  - Mac/Linux: improved tmux keybinding with version 2.4
  - Mac: improved coping and exiting from copy mode after successful copy
 
