### PR TITLE
Add default global configuration linter for markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - dotfiles: Add shunit2 bash testing framework v2.1.6 as a submodule
 - dotfiles: Add unit test environment for main bash configurator
 - dotfiles: Cover few sample methods in dotfiles configurator with unit tests
+- dotfiles/Vim: Add linter configuration for markdown and .gemrc config file (#109)
 
 ### Changed
 - Tmux: Update Linux key bindings for Tmux v2.4

--- a/bin/dotfiles
+++ b/bin/dotfiles
@@ -766,6 +766,8 @@ do_reconfigure() {
   make_symlink ".zshenv" "${PROJECT_SETTINGS_COMMON_DIR}/.zshenv" "$HOME/.zshenv"
   make_symlink ".zshrc" "${PROJECT_SETTINGS_COMMON_DIR}/.zshrc" "$HOME/.zshrc"
   make_symlink ".zshrc.local" "${PROJECT_SETTINGS_THEME_DIR}/.zshrc.local" "$HOME/.zshrc.local"
+  make_symlink ".mdlrc" "${PROJECT_SETTINGS_COMMON_DIR}/.mdlrc" "$HOME/.mdlrc"
+  make_symlink ".gemrc" "${PROJECT_SETTINGS_COMMON_DIR}/.gemrc" "$HOME/.gemrc"
 
   # $PATH variable not properly set in gvim/MacVim => http://stackoverflow.com/a/24542893/1977012
   make_symlink ".zprofile" "${PROJECT_SETTINGS_COMMON_DIR}/.zprofile" "$HOME/.zprofile"

--- a/settings/common/.gemrc
+++ b/settings/common/.gemrc
@@ -1,0 +1,16 @@
+# http://docs.rubygems.org/read/chapter/11
+---
+gem: --no-ri --no-rdoc
+benchmark: false
+verbose: true
+update_sources: true
+sources:
+- http://gems.rubyforge.org/
+- http://rubygems.org/
+backtrace: true
+bulk_threshold: 1000
+
+# HTTP Proxy options
+# http-proxy: http://example.com:80
+
+# vi:syntax=yaml

--- a/settings/common/.mdlrc
+++ b/settings/common/.mdlrc
@@ -1,0 +1,2 @@
+# disabling rules for markdownlinter
+rules "~MD022"

--- a/settings/common/.vimrc
+++ b/settings/common/.vimrc
@@ -533,6 +533,7 @@ endif
     let g:syntastic_check_on_wq = 0
 
     " if add other then linter will check one for another checker
+    let g:syntastic_markdown_mdl_exec = 'markdownlint'
     let g:syntastic_typescript_checkers = ['tslint'] " other 'tsc'
     let g:syntastic_javascript_checkers = ['eslint'] " 'standard', 'jslint'
     let g:syntastic_go_checkers = ['go', 'govet', 'golint']


### PR DESCRIPTION
Fixes #109

## Proposed Changes

* adding global markdown linter configuration
* use markdownlint (mdl) in vim
* add default .gemrc file
