### PR TITLE
Remove legacy tmux-gruvbox submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "lib/honukai-iterm-zsh"]
 	path = lib/honukai-iterm-zsh
 	url = https://github.com/oskarkrawczyk/honukai-iterm-zsh.git
-[submodule "lib/tmux-gruvbox"]
-	path = lib/tmux-gruvbox
-	url = https://github.com/egel/tmux-gruvbox
 [submodule "lib/shunit2"]
 	path = lib/shunit2
 	url = https://github.com/kward/shunit2.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - dotfiles: Cover few sample methods in dotfiles configurator with unit tests
 - dotfiles/Vim: Add linter configuration for markdown and .gemrc config file (#109)
 - Tmux: Add Tmux Plugin Manager (#97)
+- Tmux/TPM: load the tmux-grovbox theme via TPM (#113)
 
 ### Changed
 - Tmux: Update Linux key bindings for Tmux v2.4


### PR DESCRIPTION
## Proposed Changes

* removing tmux-gruvbox submodule in favor of plugin (TPM) 
* add a missing changelog entry for #113 
